### PR TITLE
Add support for Azure, OpenAI, Palm, Anthropic, Cohere Models - using litellm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ scrapeghost = 'scrapeghost.cli:main'
 [tool.poetry.dependencies]
 python = "^3.10"
 openai = "^0.27.1"
+litellm = "0.1.213"
 cssselect = "^1.2.0"
 lxml = "^4.9.2"
 structlog = "^22.3.0"

--- a/src/scrapeghost/apicall.py
+++ b/src/scrapeghost/apicall.py
@@ -4,6 +4,7 @@ Module for making OpenAI API calls.
 import time
 from dataclasses import dataclass
 import openai
+from litellm import completion
 import openai.error
 from typing import Callable
 
@@ -80,7 +81,7 @@ class OpenAiCall:
         """
         Make an OpenAPI request and return the raw response.
 
-        * model - the OpenAI model to use
+        * model - the OpenAI/Azure/Anthropic/Cohere/Replicate model to use. See list of supported models here: https://litellm.readthedocs.io/en/latest/supported/
         * messages - the messages to send to the API
         * response - the Response object to augment
 
@@ -92,7 +93,7 @@ class OpenAiCall:
                 f"Total cost {self.total_cost:.2f} exceeds max cost {self.max_cost:.2f}"
             )
         start_t = time.time()
-        completion = openai.ChatCompletion.create(
+        completion = completion(
             model=model,
             messages=messages,
             **self.model_params,


### PR DESCRIPTION
I'm the maintainer of litellm https://github.com/BerriAI/litellm - a simple & light package to call OpenAI, Azure, Cohere, Anthropic API Endpoints

This PR adds support for models from all the above mentioned providers

Here's a sample of how it's used:

```
from litellm import completion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```